### PR TITLE
Added cstdint

### DIFF
--- a/cmn/utils.cpp
+++ b/cmn/utils.cpp
@@ -30,6 +30,7 @@
 
 // Include Files
 #include "stdafx.h"
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <limits.h>


### PR DESCRIPTION
Fixes compilation error on modern GCC versions.

    utils.cpp:962:12: error: ‘intptr_t’ was not declared in this scope